### PR TITLE
Update setup.py // package_data field

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,11 +16,12 @@ setuptools.setup(
         'Documentation': 'https://debloch.readthedocs.io/en/latest/',
         'Source':'https://github.com/ccp4/electron-diffraction',
     },
-
-    # packages=['multislice','scattering','wallpp'],
     packages=setuptools.find_packages(),
     include_package_data=True,
-    package_data={'multislice/data':['splines.npy']},
+    package_data={
+       'multislice':['data/splines.npy'],
+       'scattering':['data/abcd.npy'],
+    },
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License ",


### PR DESCRIPTION
I had installation problems with package_data field. The current change made it work.. at least in the functions which used:

   b0 = bl.Bloch(args.cif,path='',u=[0,0,1],Nmax=3,Smax=0.1,opts='svt')
   b0.show_beams_vs_thickness()
   b0.convert2tiff()